### PR TITLE
fix #39

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,7 +315,7 @@ var ModalBox = React.createClass({
     var coords = {};
 
     // Fixing the position if the modal was already open or an animation was in progress
-    if (this.state.isOpen || this.state.isAnimateOpen || this.state.isAnimateClose) {
+    if (this.state.isOpen && (this.state.isAnimateOpen || this.state.isAnimateClose)) {
       var position = this.state.isOpen ? modalPosition : this.state.containerHeight;
 
       // Checking if a animation was in progress


### PR DESCRIPTION
fix [#39](https://github.com/maxs15/react-native-modalbox/issues/39)


```javascript
onContainerLayout: function(evt) {

    // Fixing the position if the modal was already open or an animation was in progress
    // fix here : When opening, `state.isOpen` could be true whereas `state.isAnimateOpen` was still false
    if (this.state.isOpen && (this.state.isAnimateOpen || this.state.isAnimateClose)) {

```