### PR TITLE
Added backdropPressToClose

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Check [index.js](https://github.com/maxs15/react-native-modalbox/blob/master/Exa
 | :------------ |:---------------:| :---------------:| :-----|
 | isOpen | false | `bool` | Open/close the modal, optional, you can use the open/close methods instead  |
 | isDisabled | false | `bool` | Disable any action on the modal (open, close, swipe)  |
+| backdropPressToClose | true | `bool` | Close the the modal by pressing on the backdrop |
 | swipeToClose | true | `bool` | Set to `true` to enable the swipe down to close feature |
 | swipeThreshold | 50 | `number` | The threshold to reach in pixels to close the modal |
 | swipeArea | - | `number` | The height in pixels of the swipeable area, window height by default |

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ var ModalBox = React.createClass({
   propTypes: {
     isOpen: React.PropTypes.bool,
     isDisabled: React.PropTypes.bool,
+    backdropPressToClose: React.PropTypes.bool,
     swipeToClose: React.PropTypes.bool,
     swipeThreshold: React.PropTypes.number,
     swipeArea: React.PropTypes.number,
@@ -55,6 +56,7 @@ var ModalBox = React.createClass({
 
   getDefaultProps: function () {
     return {
+      backdropPressToClose: true,
       swipeToClose: true,
       swipeThreshold: 50,
       position: "center",
@@ -350,7 +352,7 @@ var ModalBox = React.createClass({
 
     if (this.props.backdrop) {
       backdrop = (
-        <TouchableWithoutFeedback onPress={this.close}>
+        <TouchableWithoutFeedback onPress={this.props.backdropPressToClose ? this.close : null}>
           <Animated.View style={[styles.absolute, size, {opacity: this.state.backdropOpacity}]}>
             <View style={[styles.absolute, {backgroundColor:this.props.backdropColor, opacity: this.props.backdropOpacity}]}/>
             {this.props.backdropContent || []}


### PR DESCRIPTION
Added `backdropPressToClose` (close the the modal by pressing on the backdrop) both on `index.js` and `README.md`.

With `backdropPressToClose={false}` + `swipeToClose={false}` you can close the modal only by calling `.close()`