### PR TITLE
remove onViewLayoutCalculated immediately when closing

### DIFF
--- a/index.js
+++ b/index.js
@@ -396,6 +396,7 @@ var ModalBox = React.createClass({
   close: function() {
     if (this.props.isDisabled) return;
     if (!this.state.isAnimateClose && (this.state.isOpen || this.state.isAnimateOpen)) {
+      delete this.onViewLayoutCalculated;
       this.animateClose();
     }
   }


### PR DESCRIPTION
My app was running into race conditions where the modal would stay visible even when `isOpen` was `false`, because `isAnimateOpen` was still `true`.  My app is over-rendering and needs optimizing, which probably makes this bug appear for me much more easily.

I think I've tracked it down to the `onViewLayoutCalculated` function which gets added during open but never gets removed on close.  My guess on what can happen is `close()` is called, but then a layout pass occurs resulting in `onViewLayoutCalculated()` getting called again, which calls `animateOpen()`, and that mutates some of the state.  By immediately removing the `onViewLayoutCalculated` function I'm guessing that can be avoided, and it seems to work for me so far.