### PR TITLE
Making react-native-slider 0.25+ compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var {
   View,
   StyleSheet,
@@ -9,7 +9,7 @@ var {
   TouchableWithoutFeedback,
   Dimensions,
   Easing
-} = React;
+} = require('react-native');
 
 var screen = Dimensions.get('window');
 


### PR DESCRIPTION
react-native@0.25 deprecates `const React = require('react-native')` and asks you to use `const React = require('react')` instead. Just did that.