### PR TITLE
Allow modal to appear open without animation upon first mount

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ var ModalBox = React.createClass({
 
   getInitialState: function () {
     return {
-      position: new Animated.Value(screen.height),
+      position: this.props.startOpen ? new Animated.Value(0) : new Animated.Value(screen.height),
       backdropOpacity: new Animated.Value(0),
       isOpen: this.props.startOpen,
       isAnimateClose: false,

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ var ModalBox = React.createClass({
   propTypes: {
     isOpen: React.PropTypes.bool,
     isDisabled: React.PropTypes.bool,
+    startOpen: React.PropTypes.bool,
     backdropPressToClose: React.PropTypes.bool,
     swipeToClose: React.PropTypes.bool,
     swipeThreshold: React.PropTypes.number,
@@ -56,6 +57,7 @@ var ModalBox = React.createClass({
 
   getDefaultProps: function () {
     return {
+      startOpen: false,
       backdropPressToClose: true,
       swipeToClose: true,
       swipeThreshold: 50,
@@ -72,7 +74,7 @@ var ModalBox = React.createClass({
     return {
       position: new Animated.Value(screen.height),
       backdropOpacity: new Animated.Value(0),
-      isOpen: false,
+      isOpen: this.props.startOpen,
       isAnimateClose: false,
       isAnimateOpen: false,
       swipeToClose: false,


### PR DESCRIPTION
I am using react-native-modalbox for a login window which needs to animate on every open/close, except when the app is first opened, when it should appear immediately. This allows the behaviour I need.