### PR TITLE
Patch for issue introduced after fixing issue #67

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,11 +169,12 @@ var ModalBox = React.createClass({
     if (this.props.backdrop)
       this.animateBackdropOpen();
 
+    this.state.isAnimateOpen = true;
+  
     requestAnimationFrame(() => {
       // Detecting modal position
       this.state.positionDest = this.calculateModalPosition(this.state.containerHeight, this.state.containerWidth);
-
-      this.state.isAnimateOpen = true;
+  
       this.state.animOpen = Animated.timing(
         this.state.position,
         {


### PR DESCRIPTION
Trying to close the modal box containing an animated component failed in case the delay between open and close was very short (ex. 20ms)

After applying this fix all examples work as before.  There is however an issue with the 'slider' example.  It does not seem to work in my configuration (Android simulators).  But when I do a rollback of the last PR then the behavior is exactly the same as with my fix.  So the 'slider' issue seems to be caused by the slider component itself.

I'm not 100% sure that I didn't break the fix that was done in version 1.3.5.  I guess not as I didn't touch the animation part itself.