### PR TITLE
Added check to componentWillReceiveProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,9 @@ var ModalBox = React.createClass({
   },
 
   componentWillReceiveProps: function(props) {
-    this.handleOpenning(props);
+     if(this.props.isOpen != props.isOpen){
+        this.handleOpenning(props);
+     }
   },
 
   handleOpenning: function(props) {


### PR DESCRIPTION
This should fix the issues around the modal disappearing when it contains a component that will receive prop changes that propagate to the parent element  