### PR TITLE
Allow for custom easing prop while retaining original easing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Check [index.js](https://github.com/maxs15/react-native-modalbox/blob/master/Exa
 | backdropColor | black| `string` | backgroundColor of the backdrop
 | backdropContent | null| `ReactElement` | Add an element in the backdrop (a close button for example)
 | animationDuration | 400| `number` | Duration of the animation
+| easing | Easing.elastic(0.8) | `function` | Easing function applied to opening modal animation
 | backButtonClose | false | `bool` | (Android only) Close modal when receiving back button event
 | startOpen | false | `bool` | Allow modal to appear open without animation upon first mount
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ var ModalBox = React.createClass({
     backdropContent: React.PropTypes.element,
     animationDuration: React.PropTypes.number,
     backButtonClose: React.PropTypes.bool,
+    easing: React.PropTypes.func,
 
     onClosed: React.PropTypes.func,
     onOpened: React.PropTypes.func,
@@ -71,7 +72,8 @@ var ModalBox = React.createClass({
       backdropColor: "black",
       backdropContent: null,
       animationDuration: 400,
-      backButtonClose: false
+      backButtonClose: false,
+      easing: Easing.elastic(0.8),
     };
   },
 
@@ -192,7 +194,7 @@ var ModalBox = React.createClass({
         {
           toValue: this.state.positionDest,
           duration: this.props.animationDuration,
-          easing: Easing.elastic(0.8)
+          easing: this.props.easing,
         }
       );
       this.state.animOpen.start(() => {


### PR DESCRIPTION
Disclaimer, this picks up from #103 that wasn't completed.

This allows for a custom easing function to be passed for the opening animation. I've moved the previously hard coded easing function to a default prop and added an `easing` prop with documentation in the `README.md`.
