### PR TITLE
Added zIndex

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var styles = StyleSheet.create({
   },
 
   transparent: {
+    zIndex: 2,
     backgroundColor: 'rgba(0,0,0,0)'
   },
 


### PR DESCRIPTION
Adding this zIndex to bypass the issue when using a backdrop modal, some inputs and buttons would show above the backdrop.