### PR TITLE
Replace BackAndroid with BackHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ A react native <Modal> component, easy, fully customizable, implementing the 'sw
 ![](http://i.imgur.com/3XULLt8.gif)
 
 ## Install
+For react-native < v0.44
+
+`npm install react-native-modalbox@1.3.9`
+
+For react-native >= v0.44
 
 `npm install react-native-modalbox@latest --save`
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var {
   TouchableWithoutFeedback,
   Dimensions,
   Easing,
-  BackAndroid,
+  BackHandler,
   Platform,
 } = require('react-native');
 
@@ -410,7 +410,7 @@ var ModalBox = React.createClass({
       this.onViewLayoutCalculated = () => {
         this.setState({});
         this.animateOpen();
-        if(this.props.backButtonClose && Platform.OS === 'android') BackAndroid.addEventListener('hardwareBackPress', this.onBackPress)
+        if(this.props.backButtonClose && Platform.OS === 'android') BackHandler.addEventListener('hardwareBackPress', this.onBackPress)
         delete this.onViewLayoutCalculated;
       };
       this.setState({isAnimateOpen : true});
@@ -421,7 +421,7 @@ var ModalBox = React.createClass({
     if (this.props.isDisabled) return;
     if (!this.state.isAnimateClose && (this.state.isOpen || this.state.isAnimateOpen)) {
       this.animateClose();
-      if(this.props.backButtonClose && Platform.OS === 'android') BackAndroid.removeEventListener('hardwareBackPress', this.onBackPress)
+      if(this.props.backButtonClose && Platform.OS === 'android') BackHandler.removeEventListener('hardwareBackPress', this.onBackPress)
     }
   }
 


### PR DESCRIPTION
React native 0.44 deprecated the `BackAndroid` component in favour of `BackHandler`.
See https://facebook.github.io/react-native/docs/backandroid.html

This PR changes all uses of `BackAndroid` to `BackHandler` and adds instructions in the README for those using react-native v0.44 and those using previous versions.

Resolves #129 #128 