### PR TITLE
Fixes BackAndroid warnings on react-native0.44^

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,11 @@ var {
   Dimensions,
   Easing,
   BackAndroid,
+  BackHandler,
   Platform,
 } = require('react-native');
+
+var BackButton = BackHandler || BackAndroid;
 
 var screen = Dimensions.get('window');
 
@@ -410,7 +413,7 @@ var ModalBox = React.createClass({
       this.onViewLayoutCalculated = () => {
         this.setState({});
         this.animateOpen();
-        if(this.props.backButtonClose && Platform.OS === 'android') BackAndroid.addEventListener('hardwareBackPress', this.onBackPress)
+        if(this.props.backButtonClose && Platform.OS === 'android') BackButton.addEventListener('hardwareBackPress', this.onBackPress)
         delete this.onViewLayoutCalculated;
       };
       this.setState({isAnimateOpen : true});
@@ -421,7 +424,7 @@ var ModalBox = React.createClass({
     if (this.props.isDisabled) return;
     if (!this.state.isAnimateClose && (this.state.isOpen || this.state.isAnimateOpen)) {
       this.animateClose();
-      if(this.props.backButtonClose && Platform.OS === 'android') BackAndroid.removeEventListener('hardwareBackPress', this.onBackPress)
+      if(this.props.backButtonClose && Platform.OS === 'android') BackButton.removeEventListener('hardwareBackPress', this.onBackPress)
     }
   }
 


### PR DESCRIPTION
React native 0.44 deprecated the `BackAndroid` component in favour of `BackHandler`.
See https://facebook.github.io/react-native/docs/backandroid.html

This PR uses `BackHandler` on devices running `react-native 0.44^` and `BackAndroid` on older versions.

Resolves #128 