### PR TITLE
Add prop-types as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/maxs15/react-native-modalbox#readme",
   "dependencies": {
-    "create-react-class": "^15.6.0"
+    "create-react-class": "^15.6.0",
+    "prop-types": "^15.5.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,6 +78,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"


### PR DESCRIPTION
https://github.com/maxs15/react-native-modalbox/pull/147

`prop-types` package was used but wasn't added to dependencies, this PR fixes that