### PR TITLE
Fix backButtonClose not comply when using Modal

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,7 +450,14 @@ var ModalBox = createReactClass({
     if (!this.props.coverScreen) return content;
 
     return (
-      <Modal onRequestClose={() => this.close()} supportedOrientations={['landscape', 'portrait']} transparent visible={visible}>
+      <Modal
+        onRequestClose={() => {
+          if (this.props.backButtonClose) {
+            this.close()
+          }
+        }}
+        supportedOrientations={['landscape', 'portrait']} transparent visible={visible}
+      >
         {content}
       </Modal>
     );


### PR DESCRIPTION
Check for backButtonClose prop before calling close() in onRequestClose of Modal. This will not allow the modal to clse when backButtonClose is set to false.

Thanks for the library!