### PR TITLE
Skip zero check when calculating modal position

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,7 +304,9 @@ var ModalBox = createReactClass({
       position = containerHeight / 2 - this.state.height / 2;
     }
     // Checking if the position >= 0
-    if (position < 0) position = 0;
+    // Skip this check as it is also checked with keyboardOffsetTop.
+    // allow negative top position...
+    // if (position < 0) position = 0;
     return position;
   },
 


### PR DESCRIPTION
Allow for negative modal position during calculation. It is also checked in `animateOpen` with keyboardOffsetTop. If we allow negative in the calculation the developer can choose if its allowed or not with `keyboardOffsetTop` instead of overriding this.

 