### PR TITLE
Add 'portrait-upside-down' to supportedOrientations prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,7 +450,7 @@ var ModalBox = createReactClass({
     if (!this.props.coverScreen) return content;
 
     return (
-      <Modal onRequestClose={() => this.close()} supportedOrientations={['landscape', 'portrait']} transparent visible={visible}>
+      <Modal onRequestClose={() => this.close()} supportedOrientations={['landscape', 'portrait', 'portrait-upside-down']} transparent visible={visible}>
         {content}
       </Modal>
     );


### PR DESCRIPTION
This PR just adds 'portrait-upside-down' to modal `supportedOrientations` prop.

**Previous behavior**
If you try to open the modal in 'portrait-upside-down' mode the screen is going to change automatically his orientation because the modal does not accept this orientation.

**Now**
With this PR, the modal can be opened in all possible orientations.