### PR TITLE
Remove `BackAndroid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Check [index.js](https://github.com/maxs15/react-native-modalbox/blob/master/Exa
 
 ## Version note
 | react-native | react-native-modalbox |
+| :------------ |:---------------:|
 | <= 0.57 | <= 1.6.0 |
 | >= 0.58 | >= 1.6.1 |
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ A react native <Modal> component, easy, fully customizable, implementing the 'sw
 ## Example
 Check [index.js](https://github.com/maxs15/react-native-modalbox/blob/master/Example/index.ios.js) in the Example folder.
 
+## Version note
+| react-native | react-native-modalbox |
+| <= 0.57 | <= 1.6.0 |
+| >= 0.58 | >= 1.6.1 |
+
 ## Properties
 
 | Prop  | Default  | Type | Description |

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ var {
   TouchableWithoutFeedback,
   Dimensions,
   Easing,
-  BackAndroid,
   BackHandler,
   Platform,
   Modal,
@@ -19,7 +18,7 @@ var {
 
 var createReactClass = require('create-react-class');
 
-var BackButton = BackHandler || BackAndroid;
+var BackButton = BackHandler;
 
 var screen = Dimensions.get('window');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-modalbox",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A <Modal/> component for react-native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`BackAndroid` is totally removed from `react-native@0.58+`. 
Importing it and using it will just throw an error in runtime.