### PR TITLE
removes fixed height for dynamic content

### DIFF
--- a/index.js
+++ b/index.js
@@ -478,7 +478,6 @@ export default class ModalBox extends React.PureComponent {
 
   renderContent() {
     const size = {
-      height: this.state.containerHeight,
       width: this.state.containerWidth
     };
     const offsetX = (this.state.containerWidth - this.state.width) / 2;


### PR DESCRIPTION
Hey all,

We're using this cool lib in our app, but unfortunately we've been struggling with dynamic content. So we have a bottom modal in which the children height is variable depending on external data. I didn't manage to find a way to customise the styles to handle that, seems like it's either fixed height or full screen basically. So I'm not sure if this change is correct, but everything seems to work fine when we do this, the modal adapts to the height and still behave correctly. 

If there is another way to do this without changing the code, I'm all ears.

Thanks,
Andy