### PR TITLE
Fixed warnings "useNativeDriver was not specified"

### DIFF
--- a/index.js
+++ b/index.js
@@ -363,7 +363,7 @@ export default class ModalBox extends React.PureComponent {
       return true;
     };
 
-    const animEvt = Animated.event([null, {customY: position}]);
+    const animEvt = Animated.event([null, {customY: position}],{useNativeDriver: false});
 
     const onPanMove = (evt, state) => {
       const newClosingState =


### PR DESCRIPTION
Fixed warning "useNativeDriver was not specified" and "Animated.event now requires a second argument for options"