### PR TITLE
Add onMoveShouldSetPanResponder to trigger onPanStart

### DIFF
--- a/index.js
+++ b/index.js
@@ -395,6 +395,7 @@ export default class ModalBox extends React.PureComponent {
 
     return PanResponder.create({
       onStartShouldSetPanResponder: onPanStart,
+      onMoveShouldSetPanResponder: onPanStart,
       onPanResponderMove: onPanMove,
       onPanResponderRelease: onPanRelease,
       onPanResponderTerminate: onPanRelease


### PR DESCRIPTION
When `<Modal/>` wraps `<TouchableWithoutFeedback onPress={...}/>`, the `onPress` prop "disable" the modal's swipe gesture.
This PR fix it and allow modal gesture to work along with `onPress`.