### PR TITLE
Fix: Glitch Modal with Coverscreen Prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ export default class ModalBox extends React.PureComponent {
       isAnimateClose: false,
       isAnimateOpen: false,
       swipeToClose: false,
+      showContent: true,
       height: SCREEN_HEIGHT,
       width: SCREEN_WIDTH,
       containerHeight: SCREEN_HEIGHT,
@@ -312,11 +313,15 @@ export default class ModalBox extends React.PureComponent {
         }).start(() => {
           // Keyboard.dismiss();   // make this optional. Easily user defined in .onClosed() callback
           this.setState({
-            isAnimateClose: false,
-            animClose
+            showContent: false
           }, () => {
-            /* Set the state to the starting position of the modal, preventing from animating where the swipe stopped */
-            this.state.position.setValue(this.props.entry === 'top' ? -this.state.containerHeight : this.state.containerHeight);
+            this.setState({
+              isAnimateClose: false,
+              animClose
+            }, () => {
+              /* Set the state to the starting position of the modal, preventing from animating where the swipe stopped */
+              this.state.position.setValue(this.props.entry === 'top' ? -this.state.containerHeight : this.state.containerHeight);
+            });
           });
           if (this.props.onClosed) this.props.onClosed();
         });
@@ -547,7 +552,7 @@ export default class ModalBox extends React.PureComponent {
         transparent
         visible={visible}
         hardwareAccelerated={true}>
-        {content}
+        {this.state.showContent ? content : <View />}
       </Modal>
     );
   }
@@ -566,7 +571,10 @@ export default class ModalBox extends React.PureComponent {
           BackHandler.addEventListener('hardwareBackPress', this.onBackPress);
         this.onViewLayoutCalculated = null;
       };
-      this.setState({isAnimateOpen: true});
+      this.setState({
+        isAnimateOpen: true,
+        showContent: true
+      });
     }
   }
 


### PR DESCRIPTION
[Fix: Glitch Modal with Coverscreen Prop]

# What is going on?
Our modal (ex: BreakTimeModal) sometimes glitches after closed if we use coverScreen props. 

This glitch is mostly happen in ios

**Level: {medium}**
the glitch makes our app looks unstable for the user.

# How to reproduce?
## Condition
- using coverScreen props
- modal with heavy content

## Step
- open modal
- close modal

# Caused by
this glitch doesn't only happen in modalbox library, but also react-native-modal (issue [#1](https://github.com/react-native-modal/react-native-modal/issues/268), [#2](https://github.com/react-native-modal/react-native-modal/issues/310)) then fixed by this [PR by peteroid](https://github.com/react-native-modal/react-native-modal/pull/116). in the other hand, react-native-modalbox seems haven't fixed it yet.

if we refer to those issues, the glitch happens because the modal content is too complex for post-animation process. 

# Resolved by
we tried to fork react-native-modalbox and do same thing as the [PR by peteroid](https://github.com/react-native-modal/react-native-modal/pull/116) in react-native-modal.

the main idea is to hide/not render the content right after the animation is complete. in that way, the modal has no complex content at all to cause the glitch