### PR TITLE
fix/dynamic-height-issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,9 @@ export default class ModalBox extends React.PureComponent {
     if (this.props.isOpen != prevProps.isOpen) {
       this.handleOpenning();
     }
+    if(!this.state.isOpen){
+      this.ignoreOnOpened=false
+    }
   }
 
   componentWillUnmount() {
@@ -269,7 +272,7 @@ export default class ModalBox extends React.PureComponent {
               animOpen,
               positionDest
             });
-            if (this.props.onOpened) this.props.onOpened();
+            if (this.props.onOpened && !this.ignoreOnOpened) this.props.onOpened();
           });
         });
       }
@@ -410,9 +413,20 @@ export default class ModalBox extends React.PureComponent {
 
     // If the dimensions are still the same we're done
     let newState = {};
-    if (height !== this.state.height) newState.height = height;
-    if (width !== this.state.width) newState.width = width;
+    this.layoutChanged=false
+    if (height !== this.state.height) {
+      newState.height = height;
+      this.layoutChanged=true
+    }
+    if (width !== this.state.width) {
+      newState.width = width;
+      this.layoutChanged=true
+    }
     this.setState(newState);
+    if(this.state.isOpen && this.layoutChanged){
+      this.ignoreOnOpened=true
+      this.animateOpen();
+    }
 
     if (this.onViewLayoutCalculated) this.onViewLayoutCalculated();
   }


### PR DESCRIPTION
Currently if modal is open state and there is a content layout change, it doesn't readjust itself because of which the content looks chopped.

This PR solves this [link](https://github.com/maxs15/react-native-modalbox/issues/152), whenever there is a layout change we animate the content to a new Pos and also maintain that onOpened prop callback is not fired again